### PR TITLE
support native auth (swauth, tempauth) next to existing keystone

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ MIT license, please see the LICENSE file.  All rights reserved._
     var storage = require('storage');
     var authenticate = require('authenticate');
     
-    var authFn = async.apply(authenticate.getTokens, config);
+    ## get an authentication function. config formats are described in lib/authenticate.js
+    ## use one of these:
+    var authFn = async.apply(authenticate.getTokensKeystone, config); // for keystone auth
+    var authFn = async.apply(authenticate.getTokensNative, config); // for native auth (swauth or tempauth)
+
     var storageSwift = new storage.OpenStackStorage (authFn, function(err, res, tokens) {
       console.log('Storage constructor - err: ', err, ', tokens: ', tokens);
       var containers = storageSwift.getContainers(function(err, containers) {

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -3,7 +3,8 @@ var async = require('async');
 var url = require('url');
 
 var defaults = {
-  openstackIdentityTokens: "/v2.0/tokens"
+  openstackIdentityTokensKeystone: "/v2.0/tokens",
+  openstackIdentityTokensNative: "/auth/v1.0"
 };
 
 /*
@@ -30,9 +31,9 @@ var defaults = {
  *       storageUrl:  // the url to use for accessing storage
  *     }
  */
-var getTokens = exports.getTokens = function (options, callback) {
+var getTokensKeystone = exports.getTokensKeystone = function (options, callback) {
   var uri = url.parse(options.host);
-  uri.pathname = defaults.openstackIdentityTokens;
+  uri.pathname = defaults.openstackIdentityTokensKeystone;
   var targetURL = url.format(uri);
   request(
     {
@@ -62,6 +63,51 @@ var getTokens = exports.getTokens = function (options, callback) {
             return callback(err, res, tokens);
           }
         );
+      } else {
+        if(!err) {
+          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+        }
+        return callback(err, res, tokens);
+      }
+    }
+  );
+};
+
+/*
+ * Authenticate with a native Swift auth (like swauth or tempauth), getting auth token and the storageURL to use for Swift
+ *
+ * options:
+ *  {
+ *    "user": "feedhenry",
+ *    "pass": "PASSWORD"
+ *    "host": "http://yourserver:8080"
+ *  }
+ *
+ *
+ * callback(err, tokens)
+ *   where tokens is:
+ *     {
+ *       id:          // the token
+ *       storageUrl:  // the url to use for accessing storage
+ *     }
+ */
+var getTokensNative = exports.getTokensNative = function (options, callback) {
+ var uri = url.parse(options.host);
+ uri.pathname = defaults.openstackIdentityTokensNative;
+ var targetURL = url.format(uri);
+ request(
+   {
+     method: 'GET',
+     uri: targetURL, // http://yourserver:8080/auth/v1.0
+     headers: {"X-Storage-User": options.user, "X-Storage-Pass": options.pass}
+    },
+    function (err, res, body) {
+      var tokens = {};
+
+      if (!err && res && res.statusCode && res.statusCode === 200) {
+        tokens.id = res.headers['x-auth-token'];
+        tokens.storageUrl = res.headers['x-storage-url'];
+        return callback(err, res, tokens);
       } else {
         if(!err) {
           err = new Error("request unsuccessful, statusCode: " + res.statusCode);


### PR DESCRIPTION
works for me with tempauth.  i looked at the docs and swauth should behave the same.
(note that in my previous message to you I was wrong, the X-HTTP-Storage-URL header is returned)
