### PR TITLE
Unable to use getTokensNative when importing openstack-storage.

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 
 var auth = require('./authenticate');
 exports.authenticate = auth.getTokens;
+exports.authenticate_native = auth.getTokensNative;
 
 var OpenStackStorage = exports.OpenStackStorage = function (pAuthFunction, callback) {
   var self = this;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 var auth = require('./authenticate');
 exports.authenticate = auth.getTokens;
-exports.authenticate_native = auth.getTokensNative;
+exports.authenticateNative = auth.getTokensNative;
 
 var OpenStackStorage = exports.OpenStackStorage = function (pAuthFunction, callback) {
   var self = this;


### PR DESCRIPTION
Unable to use getTokensNative unless importing both openstack-storage and authenticate. Adding an additional export in storage.js Does not break or change any current functionality, only adds to it :)