### PR TITLE
Openstack endpoint region support & request callbacks secured

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -56,8 +56,15 @@ var getTokensKeystone = exports.getTokens = exports.getTokensKeystone = function
           },
           function (matchingItem) {
             var storageURLAttribute = options.storageURLAttribute || 'publicURL';
-            if(matchingItem && matchingItem.endpoints && matchingItem.endpoints[0] && matchingItem.endpoints[0].hasOwnProperty(storageURLAttribute)) {
-              tokens.storageUrl = matchingItem.endpoints[0][storageURLAttribute];
+            epn = 0;
+            for (i in matchingItem.endpoints) {
+              if (matchingItem.endpoints[i].region === options.region) {
+                epn = i;
+                break;
+              }
+            }
+            if(matchingItem && matchingItem.endpoints && matchingItem.endpoints[epn] && matchingItem.endpoints[0].hasOwnProperty(storageURLAttribute)) {
+              tokens.storageUrl = matchingItem.endpoints[epn][storageURLAttribute];
             } else {
               err = new Error("storageURL not available");
             }

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -51,15 +51,15 @@ var getTokensKeystone = exports.getTokens = exports.getTokensKeystone = function
         async.detect(
           respBody.access.serviceCatalog,
           function (item, cb) {
-            var doesMatch = (item.type === 'object-store') && (item.name === options.storageName);
-            return cb(doesMatch);
+            var itemMatch = (item.type === 'object-store') && (item.name === options.storageName);
+            return cb(itemMatch);
           },
           function (matchingItem) {
             async.detect(
               matchingItem.endpoints,
               function (endpoint, cb) {
-                var epMatch = (endpoint.region === options.region);
-                return cb(epMatch);
+                var endpointMatch = (!options.region) || (endpoint.region === options.region);
+                return cb(endpointMatch);
               },
               function (matchingEndpoint) {
                 var storageURLAttribute = options.storageURLAttribute || 'publicURL';

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -55,20 +55,22 @@ var getTokensKeystone = exports.getTokens = exports.getTokensKeystone = function
             return cb(doesMatch);
           },
           function (matchingItem) {
-            var storageURLAttribute = options.storageURLAttribute || 'publicURL';
-            epn = 0;
-            for (i in matchingItem.endpoints) {
-              if (matchingItem.endpoints[i].region === options.region) {
-                epn = i;
-                break;
+            async.detect(
+              matchingItem.endpoints,
+              function (endpoint, cb) {
+                var epMatch = (endpoint.region === options.region);
+                return cb(epMatch);
+              },
+              function (matchingEndpoint) {
+                var storageURLAttribute = options.storageURLAttribute || 'publicURL';
+                if(matchingEndpoint && matchingEndpoint.hasOwnProperty(storageURLAttribute)) {
+                  tokens.storageUrl = matchingEndpoint[storageURLAttribute];
+                } else {
+                  err = new Error("storageURL not available");
+                }
+                return callback(err, res, tokens);
               }
-            }
-            if(matchingItem && matchingItem.endpoints && matchingItem.endpoints[epn] && matchingItem.endpoints[0].hasOwnProperty(storageURLAttribute)) {
-              tokens.storageUrl = matchingItem.endpoints[epn][storageURLAttribute];
-            } else {
-              err = new Error("storageURL not available");
-            }
-            return callback(err, res, tokens);
+            );
           }
         );
       } else {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -26,7 +26,7 @@ OpenStackStorage.prototype.getFiles = function (containerName, callback) {
   request(
     {
       method: 'GET',
-      uri: targetURL, 
+      uri: targetURL,
       json: {},
       headers: {
         "X-Auth-Token": self.tokens.id,
@@ -34,14 +34,14 @@ OpenStackStorage.prototype.getFiles = function (containerName, callback) {
       }
     },
     function (err, res, body) {
-      if (!err && res && res.statusCode && res.statusCode >= 200 && res.statusCode <= 204) {
-        var files = body;
-        return callback(err, files);
+      var statusCode = (!res || !res.statusCode) ? 400 : res.statusCode;
+      if (!err && res && statusCode >= 200 && statusCode <= 204) {
+        return callback(err, body);
       } else {
         if(!err) {
-          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+          err = new Error("request unsuccessful, statusCode: " + statusCode);
         }
-        return callback(err, res.statusCode);
+        return callback(err, statusCode);
       }
     }
   );
@@ -59,7 +59,7 @@ OpenStackStorage.prototype.createContainer = function (containerName, callback) 
   request(
     {
       method: 'PUT',
-      uri: targetURL, 
+      uri: targetURL,
       json: {},
       headers: {
         "X-Auth-Token": self.tokens.id,
@@ -67,13 +67,14 @@ OpenStackStorage.prototype.createContainer = function (containerName, callback) 
       }
     },
     function (err, res, body) {
-      if (!err && res && res.statusCode && res.statusCode >= 200 && res.statusCode <= 204) {
-        return callback(err, res.statusCode);
+      var statusCode = (!res || !res.statusCode) ? 400 : res.statusCode;
+      if (!err && res && statusCode >= 200 && statusCode <= 204) {
+        return callback(err, statusCode);
       } else {
         if(!err) {
-          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+          err = new Error("request unsuccessful, statusCode: " + statusCode);
         }
-        return callback(err, res.statusCode);
+        return callback(err, statusCode);
       }
     }
   );
@@ -86,7 +87,7 @@ OpenStackStorage.prototype.deleteContainer = function (containerName, callback) 
   request(
     {
       method: 'DELETE',
-      uri: targetURL, 
+      uri: targetURL,
       json: {},
       headers: {
         "X-Auth-Token": self.tokens.id,
@@ -94,13 +95,14 @@ OpenStackStorage.prototype.deleteContainer = function (containerName, callback) 
       }
     },
     function (err, res, body) {
-      if (!err && res && res.statusCode && res.statusCode >= 200 && res.statusCode <= 204) {
-        return callback(err, res.statusCode);
+      var statusCode = (!res || !res.statusCode) ? 400 : res.statusCode;
+      if (!err && res && statusCode >= 200 && statusCode <= 204) {
+        return callback(err, statusCode);
       } else {
         if(!err) {
-          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+          err = new Error("request unsuccessful, statusCode: " + statusCode);
         }
-        return callback(err, res.statusCode);
+        return callback(err, statusCode);
       }
     }
   );
@@ -122,7 +124,7 @@ OpenStackStorage.prototype.putFile = function (containerName, fileToSend, callba
   var headers = {
     "X-Auth-Token": self.tokens.id,
     "Accept": "application/json"
-  }; 
+  };
   var fileStream = null;
   if(fileToSend.stream) {
     fileStream = fileToSend.stream;
@@ -133,17 +135,18 @@ OpenStackStorage.prototype.putFile = function (containerName, fileToSend, callba
   var uploadStream = request(
     {
       method: 'PUT',
-      uri: targetURL, 
+      uri: targetURL,
       headers: headers
     },
     function (err, res, body) {
-      if (!err && res && res.statusCode && res.statusCode >= 200 && res.statusCode <= 204) {
-        return callback(err, res.statusCode);
+      var statusCode = (!res || !res.statusCode) ? 400 : res.statusCode;
+      if (!err && res && statusCode >= 200 && statusCode <= 204) {
+        return callback(err, statusCode);
       } else {
         if(!err) {
-          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+          err = new Error("request unsuccessful, statusCode: " + statusCode);
         }
-        return callback(err, res.statusCode);
+        return callback(err, statusCode);
       }
     }
   );
@@ -160,7 +163,7 @@ OpenStackStorage.prototype.getFile = function (containerName, fileToReceive, cal
 
   var headers = {
     "X-Auth-Token": self.tokens.id
-  }; 
+  };
   var fileStream = null;
   if(fileToReceive.stream) {
     fileStream = fileToReceive.stream;
@@ -170,20 +173,20 @@ OpenStackStorage.prototype.getFile = function (containerName, fileToReceive, cal
   var downloadStream = request(
     {
       method: 'GET',
-      uri: targetURL, 
+      uri: targetURL,
       headers: headers
     },
     function (err, res, body) {
-      if (!err && res && res.statusCode && res.statusCode >= 200 && res.statusCode <= 204) {
-        return callback(err, res.statusCode);
+      var statusCode = (!res || !res.statusCode) ? 400 : res.statusCode;
+      if (!err && res && statusCode >= 200 && statusCode <= 204) {
+        return callback(err, statusCode);
       } else {
         if(!err) {
-          err = new Error("request unsuccessful, statusCode: " + res.statusCode);
+          err = new Error("request unsuccessful, statusCode: " + statusCode);
         }
-        return callback(err, res.statusCode);
+        return callback(err, statusCode);
       }
     }
   );
   downloadStream.pipe(fileStream);
 };
-


### PR DESCRIPTION
## Openstack endpoint region support
When your Openstack cluster has multiple regions, you get a token by region. Giving this option let the user choose the right one instead of taking the first token given in the response.

## Request callback secured
When you bump into an error with requests, the res object may be undefined. In that case, it is set to 400 (Bad Request). See : https://github.com/request/request